### PR TITLE
chore: upgrade Go SDK version to `1.0.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/gorilla/websocket v1.5.0
-	github.com/momentohq/client-sdk-go v0.10.0
+	github.com/momentohq/client-sdk-go v1.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/momentohq/client-sdk-go v0.10.0 h1:tWMlw1M5POneeZVg6bRSFbrm1BRmqCFnXQd8QouTqVQ=
 github.com/momentohq/client-sdk-go v0.10.0/go.mod h1:Sw9v3RJVTBMq0gYya9iRQUwNYlgUPbVTXeYvCFLW11Q=
+github.com/momentohq/client-sdk-go v1.0.0 h1:pctp3oEAu7FqXZG6tEVo6fiCBLk/yMRT3JohFz3NCUk=
+github.com/momentohq/client-sdk-go v1.0.0/go.mod h1:FyLAPNLKClfyMlJqYJ/QVBXeciapiYr6cMF5UycPvqE=
 github.com/onsi/ginkgo/v2 v2.8.1 h1:xFTEVwOFa1D/Ty24Ws1npBWkDYEV9BqZrsDxVrVkrrU=
 github.com/onsi/gomega v1.26.0 h1:03cDLK28U6hWvCAns6NeydX3zIm4SF3ci69ulidS32Q=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=

--- a/main.go
+++ b/main.go
@@ -1,10 +1,9 @@
 package main
 
 import (
+	"github.com/momentohq/acorn-smash-demo/internal/controllers"
 	"net/http"
 	"time"
-
-	"github.com/momentohq/acorn-smash-demo/internal/controllers"
 
 	"github.com/momentohq/client-sdk-go/auth"
 	"github.com/momentohq/client-sdk-go/config"
@@ -16,20 +15,24 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	client, err := momento.NewSimpleCacheClient(&momento.SimpleCacheClientProps{
-		Configuration:      config.LatestLaptopConfig(),
-		CredentialProvider: credProvider,
-		DefaultTTL:         60 * time.Second,
-	})
+	topicClient, err := momento.NewTopicClient(
+		config.LaptopLatest(),
+		credProvider,
+	)
 	if err != nil {
 		panic(err)
 	}
 	chatController := &controllers.ChatController{
-		MomentoClient: client,
+		MomentoTopicClient: topicClient,
 	}
 
+	cacheClient, err := momento.NewCacheClient(
+		config.LaptopLatest(),
+		credProvider,
+		60*time.Second,
+	)
 	gameController := &controllers.GameController{
-		MomentoClient: client,
+		MomentoClient: cacheClient,
 	}
 
 	http.HandleFunc("/connect", chatController.Connect)


### PR DESCRIPTION
With the release of the Go SDK `1.0.0`, there are some breaking changes that need to be addressed in the demo.
With these updates, the demo runs successfully, which I confirmed by running the demo from my branch on cloud9.